### PR TITLE
fix: correct 'build-essentials' to 'build-essential' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo apt-get update
 sudo apt-get install libusb-1.0-0-dev
 # This installs libusb 0.0.1, no need to install unless you clear what you are doing.
 # sudo apt-get install libusb-dev
-sudo apt install build-essentials cmake
+sudo apt install build-essential cmake
 ```
 
 or you can install libusb manually from: https://github.com/libusb/libusb.git


### PR DESCRIPTION
## Summary
Fix typo in README.md Linux installation instructions:
- **Before:** `sudo apt install build-essentials cmake`
- **After:** `sudo apt install build-essential cmake`

The correct Ubuntu package name is `build-essential` (singular), not `build-essentials`.

## Verification
Fixes issue #23: Ubuntu typo

## Changes
- 1 line changed in README.md line 34

---
*Submitted via Jah-yee PR workflow*